### PR TITLE
Activity types doesn't have a body in request

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ copper = copper.Copper(
 
 All the root entities modelled by the Copper API are modelled as separate classes in this SDK. The currently supported root entities are:
 
+* Users
 * Activities
 * Companies
 * People

--- a/copper_sdk/activities.py
+++ b/copper_sdk/activities.py
@@ -25,4 +25,4 @@ class Activities():
         return self.copper.post('/activities/search', { **default_body, **body})
 
     def types(self):
-        return self.copper.get('/activity_types', body)
+        return self.copper.get('/activity_types')

--- a/copper_sdk/copper.py
+++ b/copper_sdk/copper.py
@@ -1,4 +1,5 @@
 import requests, json
+from .users import Users
 from .leads import Leads
 from .activities import Activities
 from .companies import Companies
@@ -53,6 +54,9 @@ class Copper():
           print(response.text)
 
         return json.loads(response.text)
+
+    def users(self):
+        return Users(self)
 
     def leads(self):
         return Leads(self)

--- a/copper_sdk/users.py
+++ b/copper_sdk/users.py
@@ -1,0 +1,14 @@
+class Users():
+    def __init__(self, copper):
+        self.copper = copper
+
+    def get(self, id):
+        return self.copper.get(f"/users/{id}")
+
+    def list(self, body = {}):
+        default_body = {
+            'page_number': 1, # number	The page number (starting with 1) that you would like to view.	1
+            'page_size': 20, # number	The number of entries included in a page of results	20
+        }
+
+        return self.copper.post('/users/search', { **default_body, **body})


### PR DESCRIPTION
I'm guessing this was a copy/paste issue, but [the Activity Types API doesn't appear to have a body](https://developer.copper.com/activities/list-activity-types.html) and `body` was inadvertently used.