### PR TITLE
fix: update base url for copper api

### DIFF
--- a/copper_sdk/copper.py
+++ b/copper_sdk/copper.py
@@ -9,7 +9,7 @@ from copper_sdk.customer_sources import CustomerSources
 from copper_sdk.loss_reasons import LossReasons
 from copper_sdk.custom_field_definitions import CustomFieldDefinitions
 
-BASE_URL = 'https://api.prosperworks.com/developer_api/v1'
+BASE_URL = 'https://api.copper.com/developer_api'
 
 
 class Copper:


### PR DESCRIPTION
From [website](https://developer.copper.com)

```
Domain Update (Q3 2021)
Please note that we've recently updated our domain to reflect an earlier
application rebranding.

Our developer api can be found at https://api.copper.com/developer_api/,
previously it was at https://api.prosperworks.com/developer_api/.

We are currently supporting auto-redirects for requests being made to
the old domain and will continue to do so until early 2022.
```