### PR TITLE
fix: add v1 to BASE_URL path

### DIFF
--- a/copper_sdk/copper.py
+++ b/copper_sdk/copper.py
@@ -9,7 +9,7 @@ from copper_sdk.customer_sources import CustomerSources
 from copper_sdk.loss_reasons import LossReasons
 from copper_sdk.custom_field_definitions import CustomFieldDefinitions
 
-BASE_URL = 'https://api.copper.com/developer_api'
+BASE_URL = 'https://api.copper.com/developer_api/v1'
 
 
 class Copper:


### PR DESCRIPTION
So this worked when I merged PR #6, but it appears that Copper
had a redirect in place. The version is required in the path.

Re-add /v1 that was removed in PR #6. mea culpa