### PR TITLE
fix: add retry loop on copper api

### DIFF
--- a/copper_sdk/copper.py
+++ b/copper_sdk/copper.py
@@ -1,4 +1,6 @@
 import requests
+from retry import retry
+from json import JSONDecodeError
 from copper_sdk.users import Users
 from copper_sdk.leads import Leads
 from copper_sdk.account import Account
@@ -46,6 +48,7 @@ class Copper:
     def delete(self, endpoint):
         return self.api_call('delete', endpoint)
 
+    @retry(JSONDecodeError, delay=1, backoff=2, max_delay=4, tries=3)
     def api_call(self, method, endpoint, json_body=None):
         if self.debug:
             print("json_body:", json_body)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.20.0
+retry>=0.9.2


### PR DESCRIPTION
Copper's api is a bit unreliable. Its possible to get e.g. a
500 error. This adds a 3x retry loop with backoff.