### PR TITLE
feat: add support for HTTP 429 too many requests (pacing)

### DIFF
--- a/copper_sdk/copper.py
+++ b/copper_sdk/copper.py
@@ -12,6 +12,7 @@ from copper_sdk.customer_sources import CustomerSources
 from copper_sdk.loss_reasons import LossReasons
 from copper_sdk.custom_field_definitions import CustomFieldDefinitions
 from copper_sdk.tags import Tags
+from copper_sdk.exception import TooManyRequests
 
 BASE_URL = 'https://api.copper.com/developer_api/v1'
 
@@ -56,6 +57,9 @@ class Copper:
 
         # dynamically call method to handle status change
         response = self.session.request(method, self.base_url + endpoint, json=json_body)
+
+        if response.status_code == 429:
+            raise TooManyRequests('429 Server Rate Limit', response=response, json_body=json_body)
 
         if self.debug:
             print(response.text)

--- a/copper_sdk/exception.py
+++ b/copper_sdk/exception.py
@@ -1,0 +1,13 @@
+class CopperException(IOError):
+    """Base Copper Exception."""
+    def __init__(self, *args, **kwargs):
+        response = kwargs.pop('response', None)
+        self.response = response
+        self.request = kwargs.pop('request', None)
+        self.json_body = kwargs.pop('json_body', None)
+        if response is not None and not self.request and hasattr(response, 'request'):
+            self.request = self.response.request
+        super(CopperException, self).__init__(*args, **kwargs)
+
+class TooManyRequests(CopperException):
+    """Too many requests in this time period, wait and retry."""


### PR DESCRIPTION
If HTTP 429 happens, the caller will have to wait and retry.