### PR TITLE
Retry 500

### DIFF
--- a/copper_sdk/copper.py
+++ b/copper_sdk/copper.py
@@ -50,7 +50,7 @@ class Copper:
     def delete(self, endpoint, json_body=None):
         return self.api_call('delete', endpoint, json_body=json_body)
 
-    @retry(JSONDecodeError, delay=1, backoff=2, max_delay=4, tries=3)
+    @retry(exceptions=(JSONDecodeError, requests.exceptions.HTTPError), delay=1, backoff=2, max_delay=4, tries=3)
     def api_call(self, method, endpoint, json_body=None):
         if self.debug:
             print("json_body:", json_body)
@@ -63,6 +63,10 @@ class Copper:
 
         if self.debug:
             print(response.text)
+
+        body = response.json()
+        if body and "success" in body and body["success"] == False and "status" in body and body["status"] == 500:
+            raise requests.exceptions.HTTPError(endpoint, 500, "Internal copper error", None, None)
 
         return response.json()
 

--- a/copper_sdk/copper.py
+++ b/copper_sdk/copper.py
@@ -12,6 +12,7 @@ from copper_sdk.customer_sources import CustomerSources
 from copper_sdk.loss_reasons import LossReasons
 from copper_sdk.custom_field_definitions import CustomFieldDefinitions
 from copper_sdk.tags import Tags
+from copper_sdk.exception import TooManyRequests
 
 BASE_URL = 'https://api.copper.com/developer_api/v1'
 
@@ -56,6 +57,9 @@ class Copper:
 
         # dynamically call method to handle status change
         response = self.session.request(method, self.base_url + endpoint, json=json_body)
+
+        if response.status_code == 429:
+            raise TooManyRequests('429 Server Rate Limit', response=response, json_body=json_body)
 
         if self.debug:
             print(response.text)

--- a/copper_sdk/exception.py
+++ b/copper_sdk/exception.py
@@ -1,0 +1,13 @@
+class CopperException(IOError):
+    """Base Copper Exception."""
+    def __init__(self, *args, **kwargs):
+        response = kwargs.pop('response', None)
+        self.response = response
+        self.request = kwargs.pop('request', None)
+        self.json_body = kwargs.pop('json_body', None)
+        if response is not None and not self.request and hasattr(response, 'request'):
+            self.request = self.response.request
+        super(CopperException, self).__init__(*args, **kwargs)
+
+class TooManyRequests(CopperException):
+    """Too many requests in this time period, wait and retry."""


### PR DESCRIPTION

Copper API can return a body like:

```
    {
      "success": false,
      "status": 500,
      "message": "ERROR:  connection to the remote node p.evr63chvunfdza2npnctrsn6ee.db.postgresbridge.com:5432 failed with the following error: FATAL:  remaining connection slots are reserved for non-replication superuser connections\n"
    }
```

which is a temporal error. Add 500 errors into retry loop.