### PR TITLE
Add support for managing Copper webhooks

### DIFF
--- a/copper_sdk/copper.py
+++ b/copper_sdk/copper.py
@@ -13,6 +13,7 @@ from copper_sdk.loss_reasons import LossReasons
 from copper_sdk.custom_field_definitions import CustomFieldDefinitions
 from copper_sdk.tags import Tags
 from copper_sdk.exception import TooManyRequests
+from copper_sdk.webhooks import Webhooks
 
 BASE_URL = 'https://api.copper.com/developer_api/v1'
 
@@ -113,3 +114,7 @@ class Copper:
     @property
     def customfielddefinitions(self):
         return CustomFieldDefinitions(self)
+
+    @property
+    def webhooks(self):
+        return Webhooks(self)

--- a/copper_sdk/webhooks.py
+++ b/copper_sdk/webhooks.py
@@ -1,0 +1,25 @@
+from copper_sdk.base import BaseResource
+
+class Webhooks(BaseResource):
+
+    def __init__(self, copper):
+        self.copper = copper
+
+    def get(self, id):
+        return self.copper.get(f"/webhooks/{id}")
+
+    def create(self, body=None):
+        if body is None:
+            body = {}
+        return self.copper.post('/webhooks', body)
+
+    def update(self, id, body=None):
+        if body is None:
+            body = {}
+        return self.copper.put(f"/webhooks/{id}", body)
+
+    def delete(self, id):
+        return self.copper.delete(f"/webhooks/{id}")
+
+    def list(self):
+        return self.copper.get('/webhooks')


### PR DESCRIPTION
N.B. This does not provide any support for implementing a webhook in your application; it only provides CRUD support for managing webhooks within Copper.